### PR TITLE
Fix double close(2) when using EventMetadata.Close() and EventMetadata.File()

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -61,8 +61,18 @@ func main() {
 			return "", err
 		}
 
+		dataFile := data.File()
+		defer dataFile.Close()
+
+		fInfo, err := dataFile.Stat()
+		if err != nil {
+			return "", err
+		}
+
+		mTime := fInfo.ModTime()
+
 		if data.MatchMask(unix.FAN_CLOSE_WRITE) || data.MatchMask(unix.FAN_MODIFY) {
-			return fmt.Sprintf("PID:%d %s", data.GetPID(), path), nil
+			return fmt.Sprintf("PID:%d %s - %v", data.GetPID(), path, mTime), nil
 		}
 
 		return "", fmt.Errorf("fanotify: unknown event")

--- a/fanotify/fanotify.go
+++ b/fanotify/fanotify.go
@@ -133,7 +133,25 @@ func (metadata *EventMetadata) MatchMask(mask int) bool {
 // File returns pointer to os.File created from event metadata supplied Fd.
 // File needs to be Closed after usage, to prevent an Fd leak.
 func (metadata *EventMetadata) File() *os.File {
-	return os.NewFile(uintptr(metadata.Fd), "")
+	// The fd used in os.NewFile() can be garbage collected, making the fd
+	// used to create it invalid. This can be problematic, as now the fd can
+	// be closed when the os.File created here is GC/Close() or when our
+	// function Close() is used too.
+	//
+	// To avoid having so many references to the same fd and have one close
+	// silently invalidate other users, we dup() the fd. This way, a new fd
+	// is created every time File() is used and this even works if File() is
+	// used multiple times (they never point to the same fd).
+	//
+	// For more details on when this can happen, see:
+	// https://pkg.go.dev/os#File.Fd, that is referenced from:
+	// https://pkg.go.dev/os#NewFile
+	fd, err := unix.Dup(int(metadata.Fd))
+	if err != nil {
+		return nil
+	}
+
+	return os.NewFile(uintptr(fd), "")
 }
 
 // NotifyFD is a notify file handle, used by all fanotify functions.

--- a/fanotify/fanotify.go
+++ b/fanotify/fanotify.go
@@ -131,7 +131,7 @@ func (metadata *EventMetadata) MatchMask(mask int) bool {
 }
 
 // File returns pointer to os.File created from event metadata supplied Fd.
-// File needs to be Closed after usage, to prevent an Fd leak.
+// File needs to be Closed after usage.
 func (metadata *EventMetadata) File() *os.File {
 	// The fd used in os.NewFile() can be garbage collected, making the fd
 	// used to create it invalid. This can be problematic, as now the fd can


### PR DESCRIPTION
Hi!

I'm a co-worker of @alban and this PR fixes https://github.com/s3rj1k/go-fanotify/issues/5.

I created 3 commits:
 * Fix double-close when using File() : this is the commit that fixes the bug. To fix it, it just uses dup() before doing the os.NewFile().
 * Add example using File(): I just added a simple use of the File() method in the example code, so it is clear for users how it should be done (close should be called on the eventMetadata and the os.File())
 * Fix File() docs: no fd leaks are possible. This commit fixes a simple issue the doc: there are no fds leaks, it is garbage collected and closed by the go runtime. This is why we hit this issue in the first place :)

Let me know what you think.


Best,
Rodrigo